### PR TITLE
feat: parallel cracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "cc"
 version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +163,12 @@ checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
@@ -205,12 +217,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "hashsat"
 version = "0.1.0"
 dependencies = [
  "bip39",
  "bitcoin",
  "clap",
+ "rand",
  "thiserror",
 ]
 
@@ -248,10 +273,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -269,6 +309,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -390,6 +465,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,3 +545,32 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +267,7 @@ dependencies = [
  "bitcoin",
  "clap",
  "rand",
+ "rayon",
  "thiserror",
 ]
 
@@ -344,6 +376,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2024"
 bip39 = "2.2.0"
 bitcoin = "0.32.6"
 clap = { version = "4.5.42", features = ["derive"] }
+rand = "0.9.2"
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ bip39 = "2.2.0"
 bitcoin = "0.32.6"
 clap = { version = "4.5.42", features = ["derive"] }
 rand = "0.9.2"
+rayon = "1.10.0"
 thiserror = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -36,23 +36,28 @@ flowchart TD
 ```
 
 ## Usage
+
 Clone the _hashsat_ repository:
+
 ```shell
 git clone https://github.com/luisschwab/hashsat
 ```
 
 Build the binary:
+
 ```shell
 cd hashsat
 cargo build --release
 ```
 
 Install the `hashsat` binary to your system's Cargo path:
+
 ```shell
 cargo install --path .
 ```
 
 To crack a passphrase, you MUST provide a [BIP39](https://bips.dev/39/)-compliant mnemonic phrase and a target address. You can also pass a custom bitcoin network (deafults to `Bitcoin`), a custom derivation path (defaults to the standard derivation path for that address type), a search width (how many addresses will be derived on each wallet tried) and a maximum passphrase length.
+
 ```shell
 % hashsat --help
 a bitcoin passphrase cracker
@@ -62,6 +67,8 @@ Usage: hashsat [OPTIONS] --mnemonic <mnemonic> --target-address <target_address>
 Options:
   -m, --mnemonic <mnemonic>
           12, 15, 18, 21 or 24 word mnemonic
+  -a, --alphabet <alphabet>
+          The alphabet to search passphrases from. Constraining the passphrase search space will improve cracking times exponentially [default: alphanumeric] [possible values: alphanumeric, alphanumeric_uppercase, alphanumeric_lowercase, uppercase, lowercase, numeric]
   -n, --network <network>
           The bitcoin network to search for addresses at [default: bitcoin] [possible values: bitcoin, signet, testnet3, testnet4]
   -t, --target-address <target_address>
@@ -70,8 +77,8 @@ Options:
           The derivation path for your wallet. Use this flag if your wallet has a non-standard derivation path
   -s, --search-width <search_width>
           How many addresses to derive on each tried wallet. Your `target_address` derivation index has to be lower or equal to this [default: 10]
-  -l, --max-passphrase-length <max_passphrase_len>
-          The maximum passphrase lenght to be searched. Will return an error if your address is not found within the search space [default: 10]
+  -r, --passphrase-length-range <passphrase_length_range>
+          The passphrase lenght range to be searched. Will return an error if your address is not found within the search space [default: 1,10]
   -h, --help
           Print help
   -V, --version
@@ -79,6 +86,7 @@ Options:
 ```
 
 Cracking a passphrase:
+
 ```shell
 ~% hashsat -m "lady miracle someone puppy rack nuclear fan ketchup conduct cute cat client" -t bc1qjjvrq88dgknydcx4temeqef7e8yxl4dd05t2an
 
@@ -116,11 +124,13 @@ xpriv: xprv9s21ZrQH143K4HBbmL89g1cBtdszmTR8uGvNeGaip1bk6vmTy2ff1yzh4EVTmQvjHEU8G
 _hashsat_ only depends on the Rust toolchain (and the `just` command runner for development).
 
 To install the Rust toolchain:
+
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 To install `just`:
+
 ```shell
 brew install just
 ```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ _hashsat_ is a passphrase cracker for lost wallets. If you know the _Mnemonic_ b
 
 ## Design
 
-_hashsat_ is dead-simple: derive a seed from the mnemonic and passphrase, derive master `Xpriv` and `Xpub` from it, derive child keys from the master `Xpub`, and then derive addresses from those child seeds. If the target address is contained in the set, we found the passphrase. Otherwise, it keeps looking until the maximum passphrase lenght is reached.
+_hashsat_ is dead-simple: derive a seed from the mnemonic and passphrase, derive master `Xpriv` and `Xpub` from it,
+derive child keys from the master `Xpub`, and then derive addresses from those child seeds. If the target address is
+contained in the set, we found the passphrase. Otherwise, it keeps looking until the maximum passphrase lenght is reached.
 
-All possible passphrases (using the defined alphanumerical alphabet) are derived using the [Radix Conversion Algorithm](https://www.cs.colostate.edu/~cs270/.Spring12/Notes/NumberSystems) into a `impl Iterator<Item = String>`, i.e. an iterator over `String`s. Since Rust evaluates iterators lazily, we don't have to allocate memory for every possible combination. It's _allocate as you go_: only a single `String` is allocated at any given time. Then we can just `loop` over the iterator.
+All possible passphrases (using the defined alphanumerical alphabet) are derived using the
+[Radix Conversion Algorithm](https://www.cs.colostate.edu/~cs270/.Spring12/Notes/NumberSystems)
+into a `impl Iterator<Item = String>`, i.e. an iterator over `String`s. Since Rust evaluates iterators lazily,
+we don't have to allocate memory for every possible combination. It's _allocate as you go_: only a single `String` is allocated
+at any given time. Then we can just `loop` over the iterator.
 
 ```mermaid
 flowchart TD
@@ -35,6 +41,22 @@ flowchart TD
 
 ```
 
+## Installation
+
+_hashsat_ only depends on the Rust toolchain (and the `just` command runner for development).
+
+To install the Rust toolchain:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+To install `just`:
+
+```shell
+brew install just
+```
+
 ## Usage
 
 Clone the _hashsat_ repository:
@@ -56,7 +78,10 @@ Install the `hashsat` binary to your system's Cargo path:
 cargo install --path .
 ```
 
-To crack a passphrase, you MUST provide a [BIP39](https://bips.dev/39/)-compliant mnemonic phrase and a target address. You can also pass a custom bitcoin network (deafults to `Bitcoin`), a custom derivation path (defaults to the standard derivation path for that address type), a search width (how many addresses will be derived on each wallet tried) and a maximum passphrase length.
+To crack a passphrase, you MUST provide a [BIP39](https://bips.dev/39/)-compliant mnemonic phrase and a target address.
+You can also pass a custom bitcoin network (deafults to `Bitcoin`), a custom derivation path (defaults to the standard
+derivation path for that address type), a search width (how many addresses will be derived on each wallet tried) and a
+maximum passphrase length.
 
 ```shell
 % hashsat --help
@@ -88,49 +113,41 @@ Options:
 Cracking a passphrase:
 
 ```shell
-~% hashsat -m "lady miracle someone puppy rack nuclear fan ketchup conduct cute cat client" -t bc1qjjvrq88dgknydcx4temeqef7e8yxl4dd05t2an
+% hashsat -m "lady miracle someone puppy rack nuclear fan ketchup conduct cute cat client" -t bc1qjjvrq88dgknydcx4temeqef7e8yxl4dd05t2an -r 0,3 -a lowercase
 
 spinning up hashers...
 
 cracking
- "lady miracle someone puppy rack nuclear fan ketchup conduct cute cat client"
+ lady miracle someone puppy rack nuclear fan ketchup conduct cute cat client
+using alphabet
+ lowercase (abcdefghijklmnopqrstuvwxyz)
 with target address
- "bc1qjjvrq88dgknydcx4temeqef7e8yxl4dd05t2an"
+ bc1qjjvrq88dgknydcx4temeqef7e8yxl4dd05t2an
 on network
  bitcoin
 with search width of
  20 addresses (10 external + 10 internal)
-and maximum passphrase length of
- 10 characters
+and passphrase length range of
+ (0,3)
 
-\ cracking sats : abc (152,308 wallets in 3m 35s)
+hasher 0 ready!
+hasher 1 ready!
+hasher 2 ready!
+hasher 3 ready!
+
+\ cracking sats : abc (3,974 wallets in 2s)
 
 JACKPOT!
-hashsat found your lost sats in 3m 35s and 152,308 tries (708 wallets per second)
+hashsat found your lost sats in 2s and 3,974 tries (1987 wallets per second)
 
 mnemonic: lady miracle someone puppy rack nuclear fan ketchup conduct cute cat client
+alphabet: lowercase
 target address: bc1qjjvrq88dgknydcx4temeqef7e8yxl4dd05t2an
 derivation path: 84'/0'/0'
 search width: 10
-max passphrase length: 10
+passphrase length range: (0,3)
 network: bitcoin
 passphrase: abc
 xpub: xpub661MyMwAqRbcGmG4sMfA39YvSfiVAv8zGVqySezLNM8iyj6cWZyuZnKAuUxoRoc5tjF15n41yN5HqKpdg6ZgZj5ya5FKFvSCHDEuATTMeAc
 xpriv: xprv9s21ZrQH143K4HBbmL89g1cBtdszmTR8uGvNeGaip1bk6vmTy2ff1yzh4EVTmQvjHEU8GqRt6EgLt5QAUbS32vgAFkGjjgNxhiAhRaQECv7
-```
-
-## Installation
-
-_hashsat_ only depends on the Rust toolchain (and the `just` command runner for development).
-
-To install the Rust toolchain:
-
-```shell
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
-To install `just`:
-
-```shell
-brew install just
 ```

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ flowchart TD
     I -- 0 --> C
     I -- 1 --> K
 
-    A ~~~ B
-    C ~~~ D
 ```
 
 ## Usage

--- a/justfile
+++ b/justfile
@@ -1,17 +1,26 @@
 alias b := build
 alias c := check
 alias f := fmt
+alias i := install
 
 _default:
     @just --list
 
+# Build the binary in release mode
 build:
-    cargo build
+    cargo build --release
 
+# Check the code
 check:
     cargo +nightly fmt --all -- --check
     cargo check
     cargo clippy
 
+# Format the code
 fmt:
     cargo +nightly fmt
+
+# Install the binary to Cargo's PATH
+install: build
+    cargo install --path .
+    

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,24 @@ pub(crate) struct Arguments {
     )]
     pub(crate) mnemonic: String,
 
-    #[arg(short, long, value_name = "network", default_value = "bitcoin", value_parser = PossibleValuesParser::new(["bitcoin", "signet", "testnet3", "testnet4"]), help = "The bitcoin network to search for addresses at")]
+    #[arg(
+        short,
+        long,
+        value_name = "alphabet",
+        default_value = "alphanumeric",
+        value_parser = PossibleValuesParser::new(["alphanumeric", "alphanumeric_uppercase", "alphanumeric_lowercase", "uppercase", "lowercase", "numeric"]),
+        help = "The alphabet to search passphrases from. Constraining the passphrase search space will improve cracking times exponentially"
+    )]
+    pub(crate) alphabet: String,
+
+    #[arg(
+        short,
+        long,
+        value_name = "network",
+        default_value = "bitcoin",
+        value_parser = PossibleValuesParser::new(["bitcoin", "signet", "testnet3", "testnet4"]),
+        help = "The bitcoin network to search for addresses at"
+    )]
     pub(crate) network: String,
 
     #[arg(
@@ -64,6 +81,8 @@ pub(crate) struct Arguments {
 pub(crate) fn parse_cli_arguments(args: Arguments) -> Result<Wallet, HashsatError> {
     // Parse the mnemonic.
     let mnemonic = Mnemonic::from_str(&args.mnemonic)?;
+    // Parse the passphrase alphabet.
+    let alphabet = args.alphabet;
     // Parse the network.
     let network = Network::from_str(&args.network)?;
     // Parse the target address.
@@ -108,6 +127,7 @@ pub(crate) fn parse_cli_arguments(args: Arguments) -> Result<Wallet, HashsatErro
 
     Ok(Wallet {
         mnemonic,
+        alphabet,
         target_address,
         derivation_path,
         search_width,

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,8 @@ pub(crate) enum HashsatError {
     #[error("Unsupported script type: {0}")]
     UnsupportedAddressType(String),
 
-    #[error("Depleted search space of {0} chars before finding any matches")]
-    DepletedSearchSpace(usize),
+    #[error("Depleted search space of ({0},{1}) chars before finding any matches")]
+    DepletedSearchSpace(usize, usize),
 
     #[error("I/O error: {0}")]
     IOError(#[from] std::io::Error),

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ use bitcoin::{
 };
 
 /// Abstract representation of a lost wallet.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Wallet {
     /// The BIP39-compliant mnemonic.
     pub(crate) mnemonic: Mnemonic,

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,7 +23,7 @@ pub(crate) struct Wallet {
     /// The maximum search width for a parent key on the BIP32 HD tree.
     pub(crate) search_width: usize,
     /// The maximum passphrase length to search.
-    pub(crate) max_passphrase_len: usize,
+    pub(crate) passphrase_length_range: (usize, usize),
     /// The network to be searched.
     pub(crate) network: Network,
     /// The cracked passphrase.
@@ -41,7 +41,11 @@ impl fmt::Display for Wallet {
         writeln!(f, "target address: {}", self.target_address)?;
         writeln!(f, "derivation path: {}", self.derivation_path)?;
         writeln!(f, "search width: {}", self.search_width)?;
-        writeln!(f, "max passphrase length: {}", self.max_passphrase_len)?;
+        writeln!(
+            f,
+            "passphrase length range: ({},{})",
+            self.passphrase_length_range.0, self.passphrase_length_range.1
+        )?;
         writeln!(f, "network: {}", self.network)?;
         writeln!(
             f,

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,8 @@ use bitcoin::{
 pub(crate) struct Wallet {
     /// The BIP39-compliant mnemonic.
     pub(crate) mnemonic: Mnemonic,
+    /// The alphabet used to search for the passphrase.
+    pub(crate) alphabet: String,
     /// The target address where it is known coins are locked.
     pub(crate) target_address: Address,
     /// The derivation path used on the search.
@@ -35,6 +37,7 @@ pub(crate) struct Wallet {
 impl fmt::Display for Wallet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "mnemonic: {}", self.mnemonic)?;
+        writeln!(f, "alphabet: {}", self.alphabet)?;
         writeln!(f, "target address: {}", self.target_address)?;
         writeln!(f, "derivation path: {}", self.derivation_path)?;
         writeln!(f, "search width: {}", self.search_width)?;


### PR DESCRIPTION
Closes #2.

Using a different thread for each passphrase subset was stupid: shorter subsets would be depleted sooner, so their threads would sit idle. Now we use an unified `RoundRobinIter`, which is just all of the `passphrase_subset` iters merged using simple round-robin scheduling. Then `rayon`'s `par_bridge()` will automagically get the next item from the iterator and distribute it to a free thread. This way, we don't have any idle threads (`rayon` is awesome).